### PR TITLE
New: hpfo function + tests

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,21 +1,19 @@
 {
   "name": "@helicone/prompts",
-  "version": "1.0.4",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helicone/prompts",
-      "version": "1.0.4",
+      "version": "1.0.11",
       "license": "ISC",
-      "dependencies": {
-        "@types/node": "^20.14.11",
-        "typescript": "^5.5.3"
-      },
       "devDependencies": {
         "@types/jest": "^29.5.12",
+        "@types/node": "^20.14.11",
         "jest": "^29.7.0",
-        "ts-jest": "^29.2.2"
+        "ts-jest": "^29.2.2",
+        "typescript": "^5.5.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1050,6 +1048,7 @@
       "version": "20.14.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
       "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3500,6 +3499,7 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3511,7 +3511,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helicone/prompts",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Helicone Prompt Formatter is a library designed to format JSON objects with the intention of using them for LLM applications.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,6 +1,6 @@
-export { parseJSXObject } from "./objectParser";
-export { shouldBumpVersion, removeAutoInputs } from "./objectVersionChecking";
 export { autoFillInputs } from "./fillInputs";
+export { parseJSXObject } from "./objectParser";
+export { removeAutoInputs, shouldBumpVersion } from "./objectVersionChecking";
 
 const hpromptTag = "helicone-prompt-input";
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -142,6 +142,12 @@ export const parsePrompt = (prompt: string) => {
   };
 };
 
+/**
+ * Formats a prompt template by replacing placeholder tags with their corresponding values.
+ * @param prompt - The prompt template containing helicone-prompt-input placeholder tags
+ * @param variables - An object mapping variable keys to their values
+ * @returns The formatted prompt with all placeholders replaced with their values
+ */
 export const formatPrompt = (
   prompt: string,
   variables: Record<string, any>
@@ -155,3 +161,81 @@ export const formatPrompt = (
     }
   );
 };
+
+/**
+ * Removes indentation and trims leading/trailing empty lines from a string.
+ * The indentation level is determined by:
+ * 1. For multi-line strings: Uses the indentation of the second non-empty line
+ * 2. For single-line strings: Uses the indentation of that line
+ * Lines with less indentation than the determined amount are left-trimmed
+ *
+ * @param str - The string to process
+ * @returns The processed string with consistent indentation and no leading/trailing empty lines
+ */
+function dedentHpfo(str: string): string {
+  const lines = str.split(/\r?\n/);
+  // Remove leading empty lines
+  while (lines.length && lines[0].trim() === "") {
+    lines.shift();
+  }
+  // Remove trailing empty lines
+  while (lines.length && lines[lines.length - 1].trim() === "") {
+    lines.pop();
+  }
+
+  let dedentAmount = 0;
+  if (lines.length >= 2) {
+    const secondLineMatch = lines[1].match(/^(\s*)/);
+    dedentAmount = secondLineMatch ? secondLineMatch[1].length : 0;
+  } else if (lines.length === 1) {
+    const onlyLineMatch = lines[0].match(/^(\s*)/);
+    dedentAmount = onlyLineMatch ? onlyLineMatch[1].length : 0;
+  }
+
+  const outdentedLines = lines.map((line) => {
+    const currentIndentMatch = line.match(/^(\s*)/);
+    const currentIndent = currentIndentMatch ? currentIndentMatch[1].length : 0;
+    if (currentIndent >= dedentAmount) {
+      return line.slice(dedentAmount);
+    } else {
+      return line.trimStart();
+    }
+  });
+  return outdentedLines.join("\n");
+}
+
+/**
+ * A string formatter that processes template literals to normalize their indentation
+ * and remove leading/trailing empty lines. Used internally by hpfo.
+ *
+ * @param strings - The template literal string parts
+ * @param values - The interpolated values
+ * @returns The processed string with normalized indentation
+ */
+const outdentFormatter: StringFormatter = (
+  strings: TemplateStringsArray,
+  ...values: any[]
+): string => {
+  const constructed = strings.reduce(
+    (acc, str, i) => acc + str + (values[i] || ""),
+    ""
+  );
+  return dedentHpfo(constructed);
+};
+
+/**
+ * Helicone Prompt Formatter with Outdent
+ * A template literal tag that combines helicone prompt formatting with automatic indentation normalization.
+ * It removes common leading spaces and trims leading/trailing empty lines while preserving the relative
+ * indentation of the content. This is particularly useful for multi-line prompts where you want to
+ * maintain code formatting in your source files without affecting the final prompt output.
+ *
+ * @example
+ * const prompt = hpfo`
+ *   This is a multi-line prompt
+ *     with different levels of
+ *       indentation and a ${{ var: "value" }}
+ *   that will be normalized.
+ * `;
+ */
+export const hpfo = hpfc({ format: "template", chain: outdentFormatter });

--- a/typescript/tests/index.test.ts
+++ b/typescript/tests/index.test.ts
@@ -1,4 +1,5 @@
-import { hpf, parsePrompt, formatPrompt } from "../src/index";
+import { expect, test } from "@jest/globals";
+import { formatPrompt, hpf, hpfo, parsePrompt } from "../src/index";
 
 test("hpf function", () => {
   const promptWithInputs = hpf`Hello ${{ world: "variable" }}`;
@@ -43,5 +44,49 @@ test("formatPrompt function", () => {
   );
   expect(formattedPrompt).toBe(
     'Hello <helicone-prompt-input key="world">variable</helicone-prompt-input>'
+  );
+});
+
+test("hpfo function - basic", () => {
+  const promptWithInputs = hpfo`Hello ${{ world: "variable" }}`;
+  expect(promptWithInputs).toBe(
+    'Hello <helicone-prompt-input key="world" >variable</helicone-prompt-input>'
+  );
+});
+
+test("hpfo function - removes indentation", () => {
+  const promptWithInputs = hpfo`
+    This is a test with
+      different levels of
+        indentation and a ${{ var: "value" }}
+    at the end.
+  `;
+  expect(promptWithInputs).toBe(
+    'This is a test with\ndifferent levels of\n  indentation and a <helicone-prompt-input key="var" >value</helicone-prompt-input>\nat the end.'
+  );
+});
+
+test("hpfo function - trims newlines", () => {
+  const promptWithInputs = hpfo`
+
+    Hello ${{ name: "world" }}
+    How are you?
+
+  `;
+  expect(promptWithInputs).toBe(
+    'Hello <helicone-prompt-input key="name" >world</helicone-prompt-input>\nHow are you?'
+  );
+});
+
+test("hpfo function - preserves empty lines between content", () => {
+  const promptWithInputs = hpfo`
+    First line
+    
+    ${{ middle: "content" }}
+    
+    Last line
+  `;
+  expect(promptWithInputs).toBe(
+    'First line\n\n<helicone-prompt-input key="middle" >content</helicone-prompt-input>\n\nLast line'
   );
 });


### PR DESCRIPTION
Helicone Prompt Formatter with Outdent
A template literal tag that combines helicone prompt formatting with automatic indentation normalization.
It removes common leading spaces and trims leading/trailing empty lines while preserving the relative
indentation of the content. This is particularly useful for multi-line prompts where you want to
maintain code formatting in your source files without affecting the final prompt output.

**Example:**
```
const prompt = hpfo`
This is a multi-line prompt
with different levels of
indentation and a ${{ var: "value" }}
that will be normalized.
`;
```
