### PR TITLE
Fix parseJSXObject to handle strings with both static and input tags

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helicone/prompts",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Helicone Prompt Formatter is a library designed to format JSON objects with the intention of using them for LLM applications.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/src/objectParser.ts
+++ b/typescript/src/objectParser.ts
@@ -63,11 +63,35 @@ export function parseJSXObject(
   ): any {
     if (typeof obj === "string") {
       if (obj.includes("<helicone-prompt-static>")) {
-        return {
-          stringWithoutJSXTags: obj.replace(
-            /<helicone-prompt-static>(.*?)<\/helicone-prompt-static>/g,
+        // First, process static tags
+        const stringWithoutStaticTags = obj.replace(
+          /<helicone-prompt-static>(.*?)<\/helicone-prompt-static>/g,
+          "$1"
+        );
+
+        // Then, check if there are also input tags and process them
+        if (stringWithoutStaticTags.includes("<helicone-prompt-input")) {
+          // Process input tags
+          const stringWithoutJSXTags = stringWithoutStaticTags.replace(
+            /<helicone-prompt-input\s*key="[^"]*"\s*>([\s\S]*?)<\/helicone-prompt-input>/g,
             "$1"
-          ),
+          );
+
+          // Create template with self-closing input tags
+          const templateWithSelfClosingTags = obj.replace(
+            /<helicone-prompt-input\s*key="([^"]*)"\s*>([\s\S]*?)<\/helicone-prompt-input>/g,
+            (_, key, value) => {
+              inputs[key] = value.trim();
+              return `<helicone-prompt-input key="${key}" />`;
+            }
+          );
+
+          return { stringWithoutJSXTags, templateWithSelfClosingTags };
+        }
+
+        // If no input tags, just return the processed static tags
+        return {
+          stringWithoutJSXTags: stringWithoutStaticTags,
           templateWithSelfClosingTags: obj,
         };
       }

--- a/typescript/tests/hpstatic.test.ts
+++ b/typescript/tests/hpstatic.test.ts
@@ -38,6 +38,35 @@ describe("hpstatic", () => {
       '<helicone-prompt-static><script>alert("XSS")</script></helicone-prompt-static>'
     );
   });
+
+  test("should parse a string with both static and input tags", () => {
+    const inputObj = {
+      prompt:
+        '<helicone-prompt-static>You are a helpful assistant.</helicone-prompt-static> Write a story about <helicone-prompt-input key="character">a secret agent</helicone-prompt-input>',
+    };
+
+    const { objectWithoutJSXTags, templateWithInputs } =
+      parseJSXObject(inputObj);
+
+    // Check that JSX tags are removed correctly
+    expect(objectWithoutJSXTags).toEqual({
+      prompt: "You are a helpful assistant. Write a story about a secret agent",
+    });
+
+    // Check that the template is created correctly
+    expect(templateWithInputs.template).toEqual({
+      prompt:
+        '<helicone-prompt-static>You are a helpful assistant.</helicone-prompt-static> Write a story about <helicone-prompt-input key="character" />',
+    });
+
+    // Check that inputs are extracted correctly
+    expect(templateWithInputs.inputs).toEqual({
+      character: "a secret agent",
+    });
+
+    // Check that there are no auto inputs
+    expect(templateWithInputs.autoInputs).toEqual([]);
+  });
 });
 
 test("parse object with static prompt", () => {


### PR DESCRIPTION
## Problem
The `parseJSXObject` function was not correctly handling strings that contained both `<helicone-prompt-static>` and `<helicone-prompt-input>` tags in a single string. When a string contained a static tag, the function would only process that tag and return immediately, without checking for input tags.

## Solution
Modified the string handling logic in the `traverseAndTransform` function to:
1. First process the static tags
2. Then check if the resulting string contains input tags
3. If it does, process those input tags as well
4. Return the fully processed string

This allows the function to handle strings that contain both static and input tags in a single string, which is a common use case.

## Testing
Added a test case that verifies the function correctly handles a string with both static and input tags:
```typescript
test("should parse a string with both static and input tags", () => {
  const inputObj = {
    prompt:
      '<helicone-prompt-static>You are a helpful assistant.</helicone-prompt-static> Write a story about <helicone-prompt-input key="character">a secret agent</helicone-prompt-input>',
  };

  const { objectWithoutJSXTags, templateWithInputs } = parseJSXObject(inputObj);

  // Check that JSX tags are removed correctly
  expect(objectWithoutJSXTags).toEqual({
    prompt: "You are a helpful assistant. Write a story about a secret agent",
  });

  // Check that the template is created correctly
  expect(templateWithInputs.template).toEqual({
    prompt:
      '<helicone-prompt-static>You are a helpful assistant.</helicone-prompt-static> Write a story about <helicone-prompt-input key="character" />',
  });

  // Check that inputs are extracted correctly
  expect(templateWithInputs.inputs).toEqual({
    character: "a secret agent",
  });

  // Check that there are no auto inputs
  expect(templateWithInputs.autoInputs).toEqual([]);
});
```

All tests are now passing.
